### PR TITLE
Add docstrings for packages and modules

### DIFF
--- a/seacharts/__init__.py
+++ b/seacharts/__init__.py
@@ -1,2 +1,5 @@
+"""
+Contains and exposes the ENC class and its Config class for the maritime spatial API.
+"""
 from .core import Config
 from .enc import ENC

--- a/seacharts/core/__init__.py
+++ b/seacharts/core/__init__.py
@@ -1,3 +1,6 @@
+"""
+Contains core classes and functions used throughout the SeaCharts package.
+"""
 from . import files
 from . import paths
 from .config import Config

--- a/seacharts/core/config.py
+++ b/seacharts/core/config.py
@@ -1,3 +1,6 @@
+"""
+Contains the Config class for ENC configuration settings.
+"""
 from pathlib import Path
 
 import yaml
@@ -9,7 +12,7 @@ from . import paths as dcp
 
 class Config:
     """
-    Class for maintaining Electronic Navigational Charts configuration settings
+    Class for maintaining Electronic Navigational Charts configuration settings.
     """
 
     def __init__(self, config_path: Path | str = None):

--- a/seacharts/core/extent.py
+++ b/seacharts/core/extent.py
@@ -1,3 +1,6 @@
+"""
+Contains the Extent class for defining the span of spatial data.
+"""
 
 
 class Extent:

--- a/seacharts/core/files.py
+++ b/seacharts/core/files.py
@@ -1,6 +1,5 @@
 """
-Contains file/directory-related utility functions, such as functions for
-writing to csv files.
+Contains utility functions related to system files and directories.
 """
 import csv
 from collections.abc import Generator

--- a/seacharts/core/parser.py
+++ b/seacharts/core/parser.py
@@ -1,3 +1,6 @@
+"""
+Contains the DataParser class for spatial data parsing.
+"""
 import time
 import warnings
 from pathlib import Path

--- a/seacharts/core/paths.py
+++ b/seacharts/core/paths.py
@@ -1,5 +1,5 @@
 """
-Contains hard-coded paths to relevant files and directories
+Contains hard-coded paths to relevant files and directories.
 """
 from pathlib import Path
 

--- a/seacharts/core/scope.py
+++ b/seacharts/core/scope.py
@@ -1,3 +1,6 @@
+"""
+Contains the Extent class for defining details related to files of spatial data.
+"""
 from dataclasses import dataclass
 
 from seacharts.core import files

--- a/seacharts/display/__init__.py
+++ b/seacharts/display/__init__.py
@@ -1,1 +1,4 @@
+"""
+Contains the Display class for displaying and plotting maritime spatial data.
+"""
 from .display import Display

--- a/seacharts/display/colors.py
+++ b/seacharts/display/colors.py
@@ -1,3 +1,6 @@
+"""
+Contains functions and structures for color management.
+"""
 import matplotlib.colors as clr
 import matplotlib.pyplot as plt
 import numpy as np

--- a/seacharts/display/display.py
+++ b/seacharts/display/display.py
@@ -1,5 +1,6 @@
-from __future__ import annotations
-
+"""
+Contains the Display class for displaying and plotting maritime spatial data.
+"""
 import tkinter as tk
 from pathlib import Path
 from typing import Any

--- a/seacharts/display/events.py
+++ b/seacharts/display/events.py
@@ -1,3 +1,6 @@
+"""
+Contains the EventsManager class for managing display interaction events.
+"""
 from typing import Any
 
 import matplotlib.pyplot as plt

--- a/seacharts/display/features.py
+++ b/seacharts/display/features.py
@@ -1,3 +1,6 @@
+"""
+Contains the FeaturesManager class for plotting spatial features on a display.
+"""
 import shapely.geometry as geo
 from cartopy.feature import ShapelyFeature
 

--- a/seacharts/enc.py
+++ b/seacharts/enc.py
@@ -1,3 +1,6 @@
+"""
+Contains the ENC class for reading, storing and plotting maritime spatial data.
+"""
 from pathlib import Path
 
 from seacharts.core import Config

--- a/seacharts/environment/__init__.py
+++ b/seacharts/environment/__init__.py
@@ -1,1 +1,4 @@
+"""
+Contains the Environment class for collecting and manipulating loaded spatial data.
+"""
 from .environment import Environment

--- a/seacharts/environment/collection.py
+++ b/seacharts/environment/collection.py
@@ -1,3 +1,6 @@
+"""
+Contains the DataCollection abstract class for containing parsed spatial data.
+"""
 from abc import abstractmethod, ABC
 from dataclasses import dataclass, field
 

--- a/seacharts/environment/environment.py
+++ b/seacharts/environment/environment.py
@@ -1,3 +1,6 @@
+"""
+Contains the Environment class for collecting and manipulating loaded spatial data.
+"""
 from seacharts.core import Scope
 from .map import MapData
 from .user import UserData

--- a/seacharts/environment/map.py
+++ b/seacharts/environment/map.py
@@ -1,3 +1,6 @@
+"""
+Contains the MapData class for containing parsed map (charts) data.
+"""
 from dataclasses import dataclass
 
 from seacharts.core import DataParser

--- a/seacharts/environment/user.py
+++ b/seacharts/environment/user.py
@@ -1,3 +1,6 @@
+"""
+Contains the UserData class for containing user-specified spatial data.
+"""
 from seacharts.layers import Layer
 from .collection import DataCollection
 

--- a/seacharts/environment/weather.py
+++ b/seacharts/environment/weather.py
@@ -1,3 +1,6 @@
+"""
+Contains the WeatherData class for containing parsed weather data.
+"""
 from seacharts.layers import Layer
 from .collection import DataCollection
 

--- a/seacharts/layers/__init__.py
+++ b/seacharts/layers/__init__.py
@@ -1,2 +1,5 @@
+"""
+Contains data classes for containing layered spatial data.
+"""
 from .layer import Layer
 from .regions import Regions, Seabed, Land, Shore

--- a/seacharts/layers/labels.py
+++ b/seacharts/layers/labels.py
@@ -1,3 +1,6 @@
+"""
+Contains dictionaries of supported regional database labels.
+"""
 NORWEGIAN_LABELS = dict(
     Seabed=[
         dict(

--- a/seacharts/layers/layer.py
+++ b/seacharts/layers/layer.py
@@ -1,5 +1,6 @@
-from __future__ import annotations
-
+"""
+Contains the Layer class and depth-specific types for layered spatial data.
+"""
 from abc import ABC
 from dataclasses import dataclass
 

--- a/seacharts/layers/locations.py
+++ b/seacharts/layers/locations.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from abc import ABC
 from dataclasses import dataclass, field
 

--- a/seacharts/layers/regions.py
+++ b/seacharts/layers/regions.py
@@ -1,5 +1,6 @@
-from __future__ import annotations
-
+"""
+Contains the Regions class and depth-specific types for regional spatial data.
+"""
 from abc import ABC
 from dataclasses import dataclass, field
 

--- a/seacharts/shapes/__init__.py
+++ b/seacharts/shapes/__init__.py
@@ -1,3 +1,6 @@
+"""
+Contains multiple convenience classes for creating and manipulating shapes.
+"""
 from .areas import Area, Circle
 from .bodies import Rectangle, Ship
 from .lines import Arrow, Line

--- a/seacharts/shapes/areas.py
+++ b/seacharts/shapes/areas.py
@@ -1,3 +1,6 @@
+"""
+Contains convenience classes for creating and manipulating area-based shapes.
+"""
 from dataclasses import dataclass, field
 
 from shapely import geometry as geo

--- a/seacharts/shapes/bodies.py
+++ b/seacharts/shapes/bodies.py
@@ -1,3 +1,6 @@
+"""
+Contains convenience classes for creating and manipulating spatial bodies.
+"""
 from dataclasses import dataclass
 
 from shapely import geometry as geo, affinity

--- a/seacharts/shapes/lines.py
+++ b/seacharts/shapes/lines.py
@@ -1,3 +1,6 @@
+"""
+Contains convenience classes for creating and manipulating line-based shapes.
+"""
 from dataclasses import dataclass
 
 from shapely import geometry as geo

--- a/seacharts/shapes/shape.py
+++ b/seacharts/shapes/shape.py
@@ -1,5 +1,6 @@
-from __future__ import annotations
-
+"""
+Contains the Shape base class for creating and manipulating shapes.
+"""
 from abc import ABC
 from dataclasses import dataclass
 from typing import Any
@@ -21,7 +22,7 @@ class Shape(ABC):
     def buffer(self, distance: int) -> None:
         self.geometry = self.geometry.buffer(distance)
 
-    def merge(self, other: Shape) -> None:
+    def merge(self, other: "Shape") -> None:
         self.geometry = self.geometry.union(other.geometry)
 
     def closest_points(self, geometry: Any) -> geo.Point:

--- a/seacharts/shapes/types.py
+++ b/seacharts/shapes/types.py
@@ -1,3 +1,6 @@
+"""
+Contains attribute-specific subtypes for inheritance usage with the Shape class.
+"""
 from dataclasses import dataclass
 
 


### PR DESCRIPTION
Partially addresses #14 

Docs for packages and modules only. Docstrings for classes, functions and methods are postponed until #15 has been decided.